### PR TITLE
specify sender=Payment for change_payment_status receiver

### DIFF
--- a/plans_payments/models.py
+++ b/plans_payments/models.py
@@ -143,7 +143,7 @@ class Payment(BasePayment):
         )
 
 
-@receiver(status_changed)
+@receiver(status_changed, sender=Payment)
 def change_payment_status(sender, *args, **kwargs):
     payment = kwargs["instance"]
     order = payment.order

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -285,3 +285,17 @@ class TestPlansPayments(TestCase):
         )
         models.renew_accounts("sender", user, p)
         self.assertEqual(p.autorenewed_payment, False)
+
+    def test_change_payment_status_called(self):
+        """ test that change_payment_status receiver is executed when Payment.change_status is called
+            NOTE: directly patching `change_payment_status` receiver is not working
+            in this case, so we just check that `Order.status` was changed to `canceled`
+        """
+
+        user = baker.make("User")
+        baker.make("UserPlan", user=user)
+        p = baker.make("Payment", variant="default", order__user=user)
+
+        self.assertNotEqual(p.order, Order.STATUS.CANCELED)
+        p.change_status(PaymentStatus.REJECTED)
+        self.assertEqual(p.order.status, Order.STATUS.CANCELED)


### PR DESCRIPTION
Restrict `change_payment_status` receiver to Payment model 

This small fix adds `sender=Payment` to the `change_payment_status` receiver. This ensures that the receiver is triggered only when the `change_status` method is called on an instance of the `Payment` model from django-plans-payments.

Previously, in rare scenarios where multiple models inherit from `BasePayment`, the `change_payment_status` function would execute even if `change_status` was called on an instance of a different model inheriting from `BasePayment`.

Added test to make sure `change_payment_status` is executed when `Payment.change_status` is called.
