### PR TITLE
Add optional returning orders when payments are refunded

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* BlenderKit <info@blenderkit.com>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+1.3.0 (Unreleased)
+++++++++++++++++++
+
+* add optional returning orders when payments are refunded
+
 1.2.2 (2023-12-20)
 ++++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Django plans payments
     :target: https://codecov.io/gh/PetrDlouhy/django-plans-payments
 
 Almost automatic integration between `django-plans <https://github.com/django-getpaid/django-plans>`_ and `django-payments <https://github.com/mirumee/django-payments>`_.
-This will add payment buttons to the order page and automatically confirm the `Order` after the payment.
+This will add payment buttons to the order page and automatically confirm the `Order` after the payment. Optionally, it can return the corresponding order when a payment is refunded.
 
 Documentation
 -------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -24,3 +24,9 @@ Add Django plans payments's URL patterns:
         url(r'^', include(plans_payments_urls)),
         ...
     ]
+
+To enable returning orders when payments are refunded, set `PLANS_PAYMENTS_RETURN_ORDER_WHEN_PAYMENT_REFUNDED` to `True` in your settings.
+
+.. code-block:: python
+
+    PLANS_PAYMENTS_RETURN_ORDER_WHEN_PAYMENT_REFUNDED = True

--- a/plans_payments/models.py
+++ b/plans_payments/models.py
@@ -152,7 +152,15 @@ def change_payment_status(sender, *args, **kwargs):
             order.user.userplan.recurring.token_verified = True
             order.user.userplan.recurring.save()
         order.complete_order()
-    if order.status != Order.STATUS.COMPLETED and payment.status not in (
+    if (
+        getattr(settings, "PLANS_PAYMENTS_RETURN_ORDER_WHEN_PAYMENT_REFUNDED", False)
+        and payment.status == PaymentStatus.REFUNDED
+    ):
+        order._change_reason = (
+            f"Django-plans-payments: Payment status changed to {payment.status}"
+        )
+        order.return_order()
+    elif order.status != Order.STATUS.COMPLETED and payment.status not in (
         PaymentStatus.CONFIRMED,
         PaymentStatus.WAITING,
         PaymentStatus.INPUT,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
 # Additional requirements go here
 
-django-plans
+django-plans>=1.0.7
 django-payments
 django-related-admin

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "django-plans",
+        "django-plans>=1.0.7",
         "django-payments",
     ],
     license="MIT",


### PR DESCRIPTION
Integrates with the new django-plans 1.0.7