### PR TITLE
Revert "add check, that confirmed order has at least one confirmed payment"

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+1.4.1 (Unreleased)
+++++++++++++++++++
+
+* do not check whether a confirmed payment of a completed order is left anymore
+
 1.4.0 (2024-04-15)
 ++++++++++++++++++
 

--- a/plans_payments/models.py
+++ b/plans_payments/models.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from urllib.parse import urljoin
 
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.dispatch.dispatcher import receiver
 from django.urls import reverse
@@ -44,20 +44,6 @@ class Payment(BasePayment):
             models.Index(fields=["status"]),
             models.Index(fields=["status", "transaction_id"]),
         ]
-
-    def clean(self):
-        if self.order.status == Order.STATUS.COMPLETED:
-            confirmed_payment_count = self.order.payment_set.exclude(pk=self.pk)
-            confirmed_payment_count = confirmed_payment_count.filter(
-                status=PaymentStatus.CONFIRMED
-            ).count()
-            if self.status != PaymentStatus.CONFIRMED and confirmed_payment_count == 0:
-                raise ValidationError(
-                    {
-                        "status": "Can't leave confirmed order without any confirmed payment. "
-                        "Please change Order first if you still want to perform this change.",
-                    },
-                )
 
     def save(self, **kwargs):
         if "payu" in self.variant:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,30 +26,6 @@ class TestPlansPayments(TestCase):
     def setUp(self):
         pass
 
-    def test_clean(self):
-        p = models.Payment(order=baker.make("Order", status=Order.STATUS.NEW))
-        p.clean()
-        self.assertEqual(p.status, "waiting")
-
-    def test_clean_completed(self):
-        p = models.Payment(
-            order=baker.make("Order", status=Order.STATUS.COMPLETED),
-            status=PaymentStatus.CONFIRMED,
-        )
-        p.clean()
-        self.assertEqual(p.status, "confirmed")
-
-    def test_clean_completed_no_confirmed_payment(self):
-        p = models.Payment(
-            order=baker.make("Order", status=Order.STATUS.COMPLETED),
-            status=PaymentStatus.WAITING,
-        )
-        with self.assertRaisesRegex(
-            Exception, "Can't leave confirmed order without any confirmed payment."
-        ):
-            p.clean()
-        self.assertEqual(p.status, "waiting")
-
     def test_save(self):
         p = models.Payment(transaction_fee=1)
         p.save()


### PR DESCRIPTION
This reverts commit https://github.com/PetrDlouhy/django-plans-payments/commit/4457061cd7096edbc904366968684bcbd10ba745

We do not need it anymore since the automatic orders returning