### PR TITLE
Pr/autorenew schedule

### DIFF
--- a/plans_payments/models.py
+++ b/plans_payments/models.py
@@ -191,9 +191,11 @@ def change_payment_status(sender, *args, **kwargs):
             f"Django-plans-payments: Payment status changed to {payment.status}"
         )
         order.save()
-        if hasattr(order.user.userplan, "recurring"):
-            order.user.userplan.recurring.token_verified = False
-            order.user.userplan.recurring.save()
+        # Maybe we would like to re-enable this for payments statuses that will not be ever renewed
+        # (like "SAC - Account closed (do not try again)" on PayU)
+        # if hasattr(order.user.userplan, "recurring"):
+        #     order.user.userplan.recurring.token_verified = False
+        #     order.user.userplan.recurring.save()
 
 
 @receiver(account_automatic_renewal)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,7 +9,7 @@ isort
 black
 mypy
 django-stubs
-psycopg2
+psycopg2-binary
 model_bakery
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -377,10 +377,14 @@ class TestPlansPayments(TestCase):
             status=PaymentStatus.REJECTED,
         )
         userplan = baker.make("UserPlan", user=p.order.user)
-        baker.make("RecurringUserPlan", user_plan=userplan)
+        recurring_user_plan = baker.make(
+            "RecurringUserPlan", user_plan=userplan, token_verified=True
+        )
         models.change_payment_status("sender", instance=p)
         self.assertEqual(p.status, "rejected")
         self.assertEqual(p.order.status, Order.STATUS.CANCELED)
+        recurring_user_plan.refresh_from_db()
+        self.assertEqual(recurring_user_plan.token_verified, True)
 
     def test_change_payment_status_rejected_order_completed(self):
         p = models.Payment(
@@ -391,6 +395,54 @@ class TestPlansPayments(TestCase):
         models.change_payment_status("sender", instance=p)
         self.assertEqual(p.status, "rejected")
         self.assertEqual(p.order.status, Order.STATUS.COMPLETED)
+
+    def test_change_payment_status_rejected_token_verified_unchanged(self):
+        """Test that token_verified remains True when payment is rejected"""
+        p = models.Payment(
+            order=baker.make("Order", status=Order.STATUS.NEW),
+            status=PaymentStatus.REJECTED,
+        )
+        userplan = baker.make("UserPlan", user=p.order.user)
+        recurring_user_plan = baker.make(
+            "RecurringUserPlan", user_plan=userplan, token_verified=True
+        )
+        models.change_payment_status("sender", instance=p)
+        self.assertEqual(p.status, "rejected")
+        self.assertEqual(p.order.status, Order.STATUS.CANCELED)
+        recurring_user_plan.refresh_from_db()
+        self.assertEqual(recurring_user_plan.token_verified, True)
+
+    def test_change_payment_status_error_token_verified_unchanged(self):
+        """Test that token_verified remains True when payment has error status"""
+        p = models.Payment(
+            order=baker.make("Order", status=Order.STATUS.NEW),
+            status=PaymentStatus.ERROR,
+        )
+        userplan = baker.make("UserPlan", user=p.order.user)
+        recurring_user_plan = baker.make(
+            "RecurringUserPlan", user_plan=userplan, token_verified=True
+        )
+        models.change_payment_status("sender", instance=p)
+        self.assertEqual(p.status, "error")
+        self.assertEqual(p.order.status, Order.STATUS.CANCELED)
+        recurring_user_plan.refresh_from_db()
+        self.assertEqual(recurring_user_plan.token_verified, True)
+
+    def test_change_payment_status_rejected_token_verified_false_unchanged(self):
+        """Test that token_verified remains False when payment is rejected and token was never verified"""
+        p = models.Payment(
+            order=baker.make("Order", status=Order.STATUS.NEW),
+            status=PaymentStatus.REJECTED,
+        )
+        userplan = baker.make("UserPlan", user=p.order.user)
+        recurring_user_plan = baker.make(
+            "RecurringUserPlan", user_plan=userplan, token_verified=False
+        )
+        models.change_payment_status("sender", instance=p)
+        self.assertEqual(p.status, "rejected")
+        self.assertEqual(p.order.status, Order.STATUS.CANCELED)
+        recurring_user_plan.refresh_from_db()
+        self.assertEqual(recurring_user_plan.token_verified, False)
 
     def test_change_payment_status_refunded(self):
         p = models.Payment(
@@ -501,6 +553,8 @@ class TestPlansPayments(TestCase):
             renewal_triggered_by=RecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
             amount=14,
             pricing=plan_pricing.pricing,
+            token="test_token",
+            token_verified=True,
         )
         with warnings.catch_warnings(record=True) as caught_warnings:
             warnings.simplefilter("always")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stop clearing `RecurringUserPlan.token_verified` on non-success payment statuses; add tests verifying unchanged tokens; switch test dependency to `psycopg2-binary`.
> 
> - **Payments/Recurring**:
>   - Do not invalidate `user.userplan.recurring.token_verified` when payment status is non-success (e.g., `rejected`, `error`); only set to verified on `confirmed`.
>   - Add clarifying comments about possibly handling permanently non-renewable statuses.
> - **Tests**:
>   - Add/adjust tests to assert `token_verified` remains unchanged on `rejected`/`error` and various order states.
>   - Update renewal test data to include `token` and `token_verified=True`.
> - **Dependencies (tests)**:
>   - Replace `psycopg2` with `psycopg2-binary` in `requirements_test.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit beaaff5fa1c0e8fe2d235bf6d65a88355e5172ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->