### PR TITLE
Add Payment.invalidate_renew_token() with a host-app signal

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 History
 -------
 
+Unreleased
+++++++++++
+* add ``Payment.invalidate_renew_token()`` - payment providers call it when
+  the gateway reports the stored recurring token as permanently dead (e.g.
+  PayU ``INVALID_TOKEN``). The token is marked unverified so renewal tasks
+  stop selecting the account and ``get_renew_token()`` returns ``None``;
+  the new ``plans_payments.signals.renew_token_invalidated`` signal lets
+  host apps prompt the user to update their payment method.
+
 2.1.0 (2026-07-21)
 ++++++++++++++++++
 

--- a/plans_payments/models.py
+++ b/plans_payments/models.py
@@ -11,13 +11,12 @@ from django.urls import reverse
 from payments import PaymentStatus, PurchasedItem, RedirectNeeded
 from payments.models import BasePayment
 from payments.signals import status_changed
-
-from .signals import renew_token_invalidated
 from plans.base.models import AbstractRecurringUserPlan
 from plans.contrib import get_user_language, send_template_email
 from plans.models import Order
 from plans.signals import account_automatic_renewal
 
+from .signals import renew_token_invalidated
 from .views import create_payment_object
 
 logger = logging.getLogger(__name__)

--- a/plans_payments/models.py
+++ b/plans_payments/models.py
@@ -11,6 +11,8 @@ from django.urls import reverse
 from payments import PaymentStatus, PurchasedItem, RedirectNeeded
 from payments.models import BasePayment
 from payments.signals import status_changed
+
+from .signals import renew_token_invalidated
 from plans.base.models import AbstractRecurringUserPlan
 from plans.contrib import get_user_language, send_template_email
 from plans.models import Order
@@ -108,6 +110,26 @@ class Payment(BasePayment):
         except ObjectDoesNotExist:
             pass
         return None
+
+    def invalidate_renew_token(self):
+        """Mark the stored recurring token as unusable.
+
+        Called by payment providers (e.g. django-payments-payu) when the
+        gateway reports a permanent token error - retrying it can never
+        succeed. The token is marked unverified so renewal tasks stop
+        selecting the account and get_renew_token() returns None; the card
+        metadata is kept for the UI. Sends renew_token_invalidated so host
+        apps can prompt the user to update their payment method.
+        """
+        try:
+            recurring_plan = self.order.user.userplan.recurring
+        except ObjectDoesNotExist:
+            return
+        recurring_plan.token_verified = False
+        recurring_plan.save()
+        renew_token_invalidated.send(
+            sender=self.__class__, payment=self, recurring_user_plan=recurring_plan
+        )
 
     def get_renew_data(self):
         """

--- a/plans_payments/signals.py
+++ b/plans_payments/signals.py
@@ -1,0 +1,7 @@
+from django.dispatch import Signal
+
+# Sent when a payment provider reports the stored recurring token as
+# permanently dead and it gets marked unverified. Host apps can listen to
+# prompt the user to update their payment method.
+# Arguments: "payment", "recurring_user_plan"
+renew_token_invalidated = Signal()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,6 +21,7 @@ from payments import PaymentStatus
 from plans.models import Invoice, Order, RecurringUserPlan
 
 from plans_payments import models
+from plans_payments.signals import renew_token_invalidated
 
 
 class TestPlansPayments(TestCase):
@@ -196,6 +197,49 @@ class TestPlansPayments(TestCase):
             payment_provider="default",
         )
         self.assertEqual(p.get_renew_token(), "token")
+
+    def test_invalidate_renew_token(self):
+        """A permanent provider token error marks the token unverified.
+
+        Renewal tasks select only token_verified plans and get_renew_token()
+        returns None afterwards; the card metadata stays for the UI. Host
+        apps are notified via the renew_token_invalidated signal so they can
+        prompt the user to update their payment method.
+        """
+        user = baker.make("User")
+        p = models.Payment(order=baker.make("Order", user=user), variant="default")
+        userplan = baker.make("UserPlan", user=user, order__user=user)
+        recurring = baker.make(
+            "RecurringUserPlan",
+            user_plan=userplan,
+            token_verified=True,
+            token="token",
+            payment_provider="default",
+        )
+        received = []
+
+        def receiver(sender, **kwargs):
+            received.append(kwargs)
+
+        renew_token_invalidated.connect(receiver)
+        try:
+            p.invalidate_renew_token()
+        finally:
+            renew_token_invalidated.disconnect(receiver)
+
+        recurring.refresh_from_db()
+        self.assertFalse(recurring.token_verified)
+        self.assertEqual(recurring.token, "token")
+        self.assertIsNone(p.get_renew_token())
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0]["payment"], p)
+        self.assertEqual(received[0]["recurring_user_plan"], recurring)
+
+    def test_invalidate_renew_token_without_recurring(self):
+        """Without a recurring plan the call is a silent no-op."""
+        user = baker.make("User")
+        p = models.Payment(order=baker.make("Order", user=user))
+        p.invalidate_renew_token()
 
     def test_get_renew_data(self):
         """Test get_renew_data returns token when wallet is verified"""


### PR DESCRIPTION
Host-side half of PetrDlouhy/django-payments-payu#32 (production finding from BlenderKit wallet-launch monitoring: dead `INVALID_TOKEN` card tokens were retried by the renewal ladder forever and short-circuited interactive one-click users into guaranteed failures).

- `Payment.invalidate_renew_token()`: marks `recurring.token_verified = False` — renewal tasks stop selecting the account (they filter on `token_verified`), `get_renew_token()` returns `None` so interactive users get a fresh card widget, and card metadata is kept for the UI. Silent no-op without a recurring plan.
- New `plans_payments.signals.renew_token_invalidated` signal (args: `payment`, `recurring_user_plan`) so host apps can send an "update your payment method" email — for a permanently dead token, human action is the only retry path with a chance of success.

Tests included (signal delivery, token kept for UI, no-recurring no-op); the provider hook is optional on both sides, so version skew between the two packages is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)