### PR TITLE
Store only the token when set_renew_token sees a plan-change order

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+Unreleased
+++++++++++
+* ``Payment.set_renew_token`` on a plan-change order (an order without a
+  pricing) stores only the token-related values on the existing
+  ``RecurringUserPlan`` instead of re-arming it from the order, which left
+  the renewal with ``pricing=None`` and the one-off difference as its amount.
+
 2.3.0 (2026-08-19)
 ++++++++++++++++++
 * make ``CreatePaymentView`` idempotent: an attempt while a previous

--- a/plans_payments/models.py
+++ b/plans_payments/models.py
@@ -200,15 +200,30 @@ class Payment(BasePayment):
         else:
             raise ValueError(f"Invalid renewal_triggered_by: {renewal_triggered_by}")
 
-        self.order.user.userplan.set_plan_renewal(
-            order=self.order,
-            token=token,
-            payment_provider=self.variant,
-            card_expire_year=card_expire_year,
-            card_expire_month=card_expire_month,
-            card_masked_number=card_masked_number,
-            renewal_triggered_by=renewal_triggered_by,
-        )
+        userplan = self.order.user.userplan
+        if self.order.pricing_id is None and hasattr(userplan, "recurring"):
+            # A plan-change order has no pricing: it changed the plan, not how
+            # the account renews. Re-arming from it would set pricing=None and
+            # the one-off difference as the renewal amount, so only the token
+            # side is stored; the subscription's own terms stay untouched.
+            recurring = userplan.recurring
+            recurring.token = token
+            recurring.payment_provider = self.variant
+            recurring.card_expire_year = card_expire_year
+            recurring.card_expire_month = card_expire_month
+            recurring.card_masked_number = card_masked_number
+            recurring.renewal_triggered_by = renewal_triggered_by
+            recurring.save()
+        else:
+            userplan.set_plan_renewal(
+                order=self.order,
+                token=token,
+                payment_provider=self.variant,
+                card_expire_year=card_expire_year,
+                card_expire_month=card_expire_month,
+                card_masked_number=card_masked_number,
+                renewal_triggered_by=renewal_triggered_by,
+            )
 
         # Store provider-specific data in RecurringUserPlan.extra_data (if field exists)
         # This allows any provider to store additional data via kwargs (e.g., customer_id for Stripe)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -727,6 +727,7 @@ class TestPlansPayments(TestCase):
             payment_provider="default",
             renewal_triggered_by=RecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
             amount=14,
+            currency="USD",
             pricing=plan_pricing.pricing,
             token="test_token",
             token_verified=True,
@@ -740,6 +741,7 @@ class TestPlansPayments(TestCase):
         self.assertEqual(order_renewed.plan, plan_pricing.plan)
         self.assertEqual(order_renewed.pricing, plan_pricing.pricing)
         self.assertEqual(order_renewed.amount, Decimal(14))
+        self.assertEqual(order_renewed.currency, "USD")
         self.assertEqual(order_renewed.user, user)
         self.assertEqual(payment_renewed.order, order_renewed)
         self.assertEqual(payment_renewed.variant, "default")
@@ -831,6 +833,7 @@ class TestPlansPayments(TestCase):
             payment_provider="default",
             renewal_triggered_by=RecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
             amount=14,
+            currency="USD",
             pricing=plan_pricing.pricing,
             token="test_token",
             token_verified=True,
@@ -882,6 +885,7 @@ class TestPlansPayments(TestCase):
             payment_provider="default",
             renewal_triggered_by=RecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
             amount=14,
+            currency="USD",
             pricing=plan_pricing.pricing,
             token="test_token",
             token_verified=True,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -352,9 +352,7 @@ class TestPlansPayments(TestCase):
             token_verified=True,
             renewal_triggered_by=RecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
         )
-        change_order = baker.make(
-            "Order", user=user, pricing=None, amount=Decimal("7.00"), currency="EUR"
-        )
+        change_order = baker.make("Order", user=user, pricing=None, amount=Decimal("7.00"), currency="EUR")
         p = models.Payment(order=change_order, variant="payu-recurring")
 
         p.set_renew_token(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -333,6 +333,51 @@ class TestPlansPayments(TestCase):
             self.assertEqual(userplan.recurring.extra_data["customer_id"], "cus_123")
             self.assertEqual(userplan.recurring.extra_data["other_field"], "value")
 
+    def test_set_renew_token_on_plan_change_order_keeps_subscription_terms(self):
+        """A plan-change order carries no pricing. Storing its token must not
+        re-arm the renewal from it - that left pricing=None and the one-off
+        difference as the amount, a subscription that renews nothing."""
+        user = baker.make("User")
+        userplan = baker.make("UserPlan", user=user)
+        pricing = baker.make("Pricing", period=30)
+        baker.make(
+            "RecurringUserPlan",
+            user_plan=userplan,
+            pricing=pricing,
+            amount=Decimal("10.00"),
+            tax=Decimal("20"),
+            currency="USD",
+            token="old-token",
+            payment_provider="default",
+            token_verified=True,
+            renewal_triggered_by=RecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
+        )
+        change_order = baker.make(
+            "Order", user=user, pricing=None, amount=Decimal("7.00"), currency="EUR"
+        )
+        p = models.Payment(order=change_order, variant="payu-recurring")
+
+        p.set_renew_token(
+            "new-token",
+            card_expire_year=2030,
+            card_expire_month=1,
+            card_masked_number="9999",
+            renewal_triggered_by="task",
+        )
+
+        userplan.recurring.refresh_from_db()
+        self.assertEqual(userplan.recurring.pricing, pricing)
+        self.assertEqual(userplan.recurring.amount, Decimal("10.00"))
+        self.assertEqual(userplan.recurring.tax, Decimal("20"))
+        self.assertEqual(userplan.recurring.currency, "USD")
+        self.assertEqual(userplan.recurring.token, "new-token")
+        self.assertEqual(userplan.recurring.payment_provider, "payu-recurring")
+        self.assertEqual(userplan.recurring.card_masked_number, "9999")
+        self.assertEqual(
+            userplan.recurring.renewal_triggered_by,
+            RecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
+        )
+
     def test_set_renew_token_task(self):
         user = baker.make("User")
         p = models.Payment(order=baker.make("Order", user=user))


### PR DESCRIPTION
## The bug

A plan-change order (django-plans `extend_account(plan, pricing=None)`) carries no pricing — it changes the plan, not how the account renews. `Payment.set_renew_token` re-armed the `RecurringUserPlan` from it through `set_plan_renewal`, which copies the order verbatim: the renewal ended up with `pricing=None` and the one-off difference as its `amount` — **a subscription that renews nothing**. Any change order paid with a recurring variant hits this.

## The fix

When the order has no pricing and a renewal already exists, `set_renew_token` stores only the token side — token, provider, card details, trigger — on the existing recurring and leaves pricing/amount/tax/currency alone. Orders with a pricing take the unchanged `set_plan_renewal` path. This is deliberately defensive so it holds with django-plans releases before the companion fix (https://github.com/django-getpaid/django-plans/pull/250), which makes `set_plan_renewal` itself keep the terms.

## Tests

New `test_set_renew_token_on_plan_change_order_keeps_subscription_terms`; the existing `set_renew_token` tests (whose baker orders have no pricing but no armed renewal) are unaffected. Suite: 77 tests, all pass. Two test-only fixes ride along so CI is green: the three `test_renew_accounts*` fixtures now arm the recurring plan with a `currency` (django-plans 2.6 made `Order.currency` NOT NULL and `create_renew_order` copies it from the recurring plan; these errored on `master` too), and the new test is formatted with the pinned black 25.12. `pre-commit run --all-files` passes.
